### PR TITLE
Add more information for parameter 'help' to renderer.

### DIFF
--- a/framework/ramses-framework/include/RamsesFrameworkConfigImpl.h
+++ b/framework/ramses-framework/include/RamsesFrameworkConfigImpl.h
@@ -54,6 +54,8 @@ namespace ramses
         ERamsesShellType m_shellType;
         ramses_internal::ThreadWatchdogConfig m_watchdogConfig;
         bool m_periodicLogsEnabled;
+
+        static void PrintCommandLineOptions();
     private:
         RamsesFrameworkConfigImpl();
 

--- a/framework/ramses-framework/src/RamsesFrameworkConfigImpl.cpp
+++ b/framework/ramses-framework/src/RamsesFrameworkConfigImpl.cpp
@@ -24,6 +24,50 @@ namespace ramses
     static bool gHasTCPComm = false;
 #endif
 
+    struct TCPCommandLineArguments
+    {
+        explicit TCPCommandLineArguments(const TCPConfig& config)
+            : useFakeConnection                  ("fakeConnection", "fakeConnection", false, "fake connection")
+            , isRamshEnabled                     ("ramsh", "ramsh", false, "ramsh")
+            , enableOffsetPlatformProtocolVersion("pvo", "protocolVersionOffset", false, "protocol version offset")
+            , disablePeriodicLogs                ("disablePeriodicLogs", "disablePeriodicLogs", false, "disable periodic logs")
+            , userProvidedGuid                   ("guid", "guid", "", "guid")
+            , port                               ("myport", "myportnumber", config.getPort(), "my port number")
+            , ipAddress                          ("myip", "myipaddress", config.getIPAddress(), "my ip address")
+            , daemonIP                           ("i", "daemon-ip", config.getDaemonIPAddress(), "daemon ip")
+            , daemonPort                         ("p", "daemon-port", config.getDaemonPort(), "daemon port")
+        {
+        }
+
+        ArgumentBool   useFakeConnection;
+        ArgumentBool   isRamshEnabled;
+        ArgumentBool   enableOffsetPlatformProtocolVersion;
+        ArgumentBool   disablePeriodicLogs;
+        ArgumentString userProvidedGuid;
+        ArgumentUInt16 port;
+        ArgumentString ipAddress;
+        ArgumentString daemonIP;
+        ArgumentUInt16 daemonPort;
+
+        void print()
+        {
+            LOG_INFO_F(CONTEXT_RENDERER, ([&](StringOutputStream& sos) {
+                        sos << "\nTCP arguments:\n";
+
+                        sos << useFakeConnection.getHelpString();
+                        sos << isRamshEnabled.getHelpString();
+                        sos << enableOffsetPlatformProtocolVersion.getHelpString();
+                        sos << disablePeriodicLogs.getHelpString();
+                        sos << userProvidedGuid.getHelpString();
+                        sos << port.getHelpString();
+                        sos << ipAddress.getHelpString();
+                        sos << daemonPort.getHelpString();
+                        sos << daemonIP.getHelpString();
+                    }));
+
+        }
+    };
+
     RamsesFrameworkConfigImpl::RamsesFrameworkConfigImpl(int32_t argc, char const* const* argv)
         : StatusObjectImpl()
         , m_shellType(ERamsesShellType_Default)
@@ -194,5 +238,12 @@ namespace ramses
     ramses_internal::Guid RamsesFrameworkConfigImpl::getUserProvidedGuid() const
     {
         return m_userProvidedGuid;
+    }
+
+    void RamsesFrameworkConfigImpl::PrintCommandLineOptions()
+    {
+        const TCPConfig defaultConfig;
+        TCPCommandLineArguments tcpArgs(defaultConfig);
+        tcpArgs.print();
     }
 }

--- a/renderer/ramses-renderer-main/src/main.cpp
+++ b/renderer/ramses-renderer-main/src/main.cpp
@@ -17,6 +17,7 @@
 #include "DisplayManager/DisplayManager.h"
 #include "Common/Cpp11Macros.h"
 #include "PlatformAbstraction/PlatformThread.h"
+#include "RamsesFrameworkConfigImpl.h"
 
 struct MappingCommand
 {
@@ -56,6 +57,7 @@ ramses_internal::Int32 main(ramses_internal::Int32 argc, char * argv[])
     if (helpRequested)
     {
         ramses_internal::RendererConfigUtils::PrintCommandLineOptions();
+        ramses::RamsesFrameworkConfigImpl::PrintCommandLineOptions();
         return 0;
     }
 


### PR DESCRIPTION
The parameters for RamsesFramework was missing. So that the user might not know how to set the IPs when the daemon and renderer were not at the same ECU.
