### PR TITLE
Fix building of Harfbuzz

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -105,6 +105,13 @@ IF (ramses-sdk_ALLOW_CUSTOM_FREETYPE AND NOT freetype_FOUND)
     set(OLD_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
     set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_MODULE_PATH})
 
+    # Checking the availability of the functions below by harfbuzz does not work, because
+    # check_function_exists() checks against an existing platform freetype library.
+    # The freetype version from external does not support those functions, so set them to off manually:
+    set(HAVE_FT_GET_VAR_BLEND_COORDINATES OFF CACHE BOOL "" FORCE)
+    set(HAVE_FT_SET_VAR_BLEND_COORDINATES OFF CACHE BOOL "" FORCE)
+    set(HAVE_FT_DONE_MM_VAR OFF CACHE BOOL "" FORCE)
+
     ADD_SUBDIRECTORY(harfbuzz)
     ACME_INFO("+ harfbuzz")
 


### PR DESCRIPTION
Building of Harfbuzz was failing when ramses-sdk_ALLOW_PLATFORM_FREETYPE
is set to OFF and a Freetype libraray >= 2.7.1 is already installed in
the platform.

Hafbuzz CMakeLists.txt uses CMake's check_function_exists() to check
for the existence of this Freetype functions:

FT_Get_Var_Blend_Coordinates
FT_Set_Var_Blend_Coordinates
FT_Done_MM_Var

This functions are available since Freetype version 2.7.1. The
delivered Freetype version that comes with RAMSES is 2.6, which does
not have this functions.

Now, when a Freetype libaray >= 2.7.1 is installed in the platform,
check_function_exists() will return TRUE for the functions, and
the build will fail later in hb-ft.cc when the functions are tried
to be called, but are not declared in the Freetype version from RAMSES.