### PR TITLE
renderer: fix compile error while wayland < 1.13

### DIFF
--- a/renderer/Platform/EmbeddedCompositor_Wayland/src/WaylandDisplay.cpp
+++ b/renderer/Platform/EmbeddedCompositor_Wayland/src/WaylandDisplay.cpp
@@ -104,11 +104,10 @@ namespace ramses_internal
             return false;
         }
 #else
-        UNUSED(display)
-        UNUSED(sock_fd)
+        UNUSED(socketFD)
         LOG_ERROR(CONTEXT_RENDERER,
                   "WaylandDisplay::addSocketToDisplayWithFD(): Wayland version is less than 1.13, "
-                  "wl_display_add_socket_fd not supported!")
+                  "wl_display_add_socket_fd not supported!");
 
         return false;
 #endif


### PR DESCRIPTION
compile error log:

error: ‘display’ was not declared in this scope
error: ‘sock_fd’ was not declared in this scope
error: expected ‘;’ before ‘return’
error: unused parameter ‘socketFD’ [-Werror=unused-parameter]

Signed-off-by: Phong Tran <tranmanphong@gmail.com>