### PR TITLE
Renderer: backend EGL ES 2.0 Wayland and X11 platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,8 +187,11 @@ ACME2_PROJECT(
                                 AUTO renderer/Platform/Platform_Windows_WGL_4_2_core
                                 AUTO renderer/Platform/Platform_Windows_WGL_4_5
                                 AUTO renderer/Platform/Platform_Windows_WGL_ES_3_0
+                                AUTO renderer/Platform/Platform_Wayland_IVI_EGL_ES_2_0
                                 AUTO renderer/Platform/Platform_Wayland_IVI_EGL_ES_3_0
+                                AUTO renderer/Platform/Platform_Wayland_Shell_EGL_ES_2_0
                                 AUTO renderer/Platform/Platform_Wayland_Shell_EGL_ES_3_0
+                                AUTO renderer/Platform/Platform_X11_EGL_ES_2_0
                                 AUTO renderer/Platform/Platform_X11_EGL_ES_3_0
                                 AUTO renderer/Platform/Platform_Android_EGL_ES_3_0
 

--- a/cmake/ramses/rendererModulePerConfig.cmake
+++ b/cmake/ramses/rendererModulePerConfig.cmake
@@ -7,9 +7,12 @@
 #  -------------------------------------------------------------------------
 
 SET(RENDERER_CONFIG_LIST
+    "x11-egl-es-2-0"
     "x11-egl-es-3-0"
 
+    "wayland-ivi-egl-es-2-0"
     "wayland-ivi-egl-es-3-0"
+    "wayland-shell-egl-es-2-0"
     "wayland-shell-egl-es-3-0"
 
     "windows-wgl-es-3-0"

--- a/renderer/Platform/Platform_Wayland_IVI_EGL_ES_2_0/CMakeLists.txt
+++ b/renderer/Platform/Platform_Wayland_IVI_EGL_ES_2_0/CMakeLists.txt
@@ -1,0 +1,29 @@
+#  -------------------------------------------------------------------------
+#  Copyright (C) 2018 BMW Car IT GmbH
+#  -------------------------------------------------------------------------
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#  -------------------------------------------------------------------------
+
+ACME_MODULE(
+
+    #==========================================================================
+    # general module information
+    #==========================================================================
+    NAME                    platform-wayland-ivi-egl-es-2-0
+    TYPE                    STATIC_LIBRARY
+    ENABLE_INSTALL          ${ramses-sdk_INSTALL_STATIC_LIBS}
+
+    #==========================================================================
+    # files of this module
+    #==========================================================================
+    FILES_PRIVATE_HEADER    include/Platform_Wayland_IVI_EGL_ES_2_0/*.h
+    FILES_SOURCE            src/*.cpp
+
+    #==========================================================================
+    # dependencies
+    #==========================================================================
+    DEPENDENCIES            PlatformFactory_Wayland_IVI_EGL
+                            Device_GL
+)

--- a/renderer/Platform/Platform_Wayland_IVI_EGL_ES_2_0/include/Platform_Wayland_IVI_EGL_ES_2_0/Platform_Wayland_IVI_EGL_ES_2_0.h
+++ b/renderer/Platform/Platform_Wayland_IVI_EGL_ES_2_0/include/Platform_Wayland_IVI_EGL_ES_2_0/Platform_Wayland_IVI_EGL_ES_2_0.h
@@ -1,0 +1,29 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2015 BMW Car IT GmbH
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#ifndef RAMSES_PLATFORM_WAYLAND_IVI_EGL_ES_2_0_H
+#define RAMSES_PLATFORM_WAYLAND_IVI_EGL_ES_2_0_H
+
+#include "PlatformFactory_Wayland_IVI_EGL/PlatformFactory_Wayland_IVI_EGL.h"
+
+namespace ramses_internal
+{
+    class Platform_Wayland_IVI_EGL_ES_2_0 : public PlatformFactory_Wayland_IVI_EGL
+    {
+    public:
+        Platform_Wayland_IVI_EGL_ES_2_0(const RendererConfig& rendererConfig);
+
+        virtual IDevice*      createDevice(IContext& context) override final;
+
+    protected:
+        void getContextAttributes(Vector<EGLint>& attributes) const override final;
+        void getSurfaceAttributes(UInt32 msaaSampleCount, Vector<EGLint>& attributes) const override final;
+    };
+}
+
+#endif

--- a/renderer/Platform/Platform_Wayland_IVI_EGL_ES_2_0/src/Platform_Wayland_IVI_EGL_ES_2_0.cpp
+++ b/renderer/Platform/Platform_Wayland_IVI_EGL_ES_2_0/src/Platform_Wayland_IVI_EGL_ES_2_0.cpp
@@ -1,0 +1,77 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2015 BMW Car IT GmbH
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#include "Platform_Wayland_IVI_EGL_ES_2_0/Platform_Wayland_IVI_EGL_ES_2_0.h"
+#include <EGL/egl.h>
+#include "Context_EGL/Context_EGL.h"
+#include "Device_GL/Device_GL.h"
+#include "Utils/LogMacros.h"
+
+namespace ramses_internal
+{
+    IPlatformFactory* PlatformFactory_Base::CreatePlatformFactory(const RendererConfig& rendererConfig)
+    {
+        return new Platform_Wayland_IVI_EGL_ES_2_0(rendererConfig);
+    }
+
+    Platform_Wayland_IVI_EGL_ES_2_0::Platform_Wayland_IVI_EGL_ES_2_0(const RendererConfig& rendererConfig)
+        : PlatformFactory_Wayland_IVI_EGL(rendererConfig)
+    {
+    }
+
+    IDevice* Platform_Wayland_IVI_EGL_ES_2_0::createDevice(IContext& context)
+    {
+        Context_EGL* platformContext = getPlatformContext<Context_EGL>(context);
+        assert(0 != platformContext);
+        Device_GL* device = new Device_GL(*platformContext, 2, 0, true);
+        return addPlatformDevice(device);
+    }
+
+    void Platform_Wayland_IVI_EGL_ES_2_0::getSurfaceAttributes(UInt32 msaaSampleCount, Vector<EGLint>& attributes) const
+    {
+        attributes.clear();
+        attributes.reserve(20u);
+
+        attributes.push_back(EGL_SURFACE_TYPE);
+        attributes.push_back(EGL_WINDOW_BIT);
+
+        attributes.push_back(EGL_RENDERABLE_TYPE);
+        attributes.push_back(EGL_OPENGL_ES2_BIT);
+
+        attributes.push_back(EGL_RED_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_ALPHA_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_DEPTH_SIZE);
+        attributes.push_back(24);
+
+        attributes.push_back(EGL_STENCIL_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_SAMPLE_BUFFERS);
+        attributes.push_back((msaaSampleCount > 1) ? 1 : 0);
+
+        attributes.push_back(EGL_SAMPLES);
+        attributes.push_back((msaaSampleCount > 1) ? msaaSampleCount : 0);
+
+        attributes.push_back(EGL_NONE);
+    }
+
+    void Platform_Wayland_IVI_EGL_ES_2_0::getContextAttributes(Vector<EGLint>& attributes) const
+    {
+        attributes.clear();
+        attributes.reserve(2u);
+
+        attributes.push_back(EGL_CONTEXT_CLIENT_VERSION);
+        attributes.push_back(2);
+
+        attributes.push_back(EGL_NONE);
+    }
+}

--- a/renderer/Platform/Platform_Wayland_Shell_EGL_ES_2_0/CMakeLists.txt
+++ b/renderer/Platform/Platform_Wayland_Shell_EGL_ES_2_0/CMakeLists.txt
@@ -1,0 +1,29 @@
+#  -------------------------------------------------------------------------
+#  Copyright (C) 2018 BMW Car IT GmbH
+#  -------------------------------------------------------------------------
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#  -------------------------------------------------------------------------
+
+ACME_MODULE(
+
+    #==========================================================================
+    # general module information
+    #==========================================================================
+    NAME                    platform-wayland-shell-egl-es-2-0
+    TYPE                    STATIC_LIBRARY
+    ENABLE_INSTALL          ${ramses-sdk_INSTALL_STATIC_LIBS}
+
+    #==========================================================================
+    # files of this module
+    #==========================================================================
+    FILES_PRIVATE_HEADER    include/Platform_Wayland_Shell_EGL_ES_2_0/*.h
+    FILES_SOURCE            src/*.cpp
+
+    #==========================================================================
+    # dependencies
+    #==========================================================================
+    DEPENDENCIES            PlatformFactory_Wayland_Shell_EGL
+                            Device_GL
+)

--- a/renderer/Platform/Platform_Wayland_Shell_EGL_ES_2_0/include/Platform_Wayland_Shell_EGL_ES_2_0/Platform_Wayland_Shell_EGL_ES_2_0.h
+++ b/renderer/Platform/Platform_Wayland_Shell_EGL_ES_2_0/include/Platform_Wayland_Shell_EGL_ES_2_0/Platform_Wayland_Shell_EGL_ES_2_0.h
@@ -1,0 +1,29 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2017 BMW Car IT GmbH
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#ifndef RAMSES_PLATFORM_WAYLAND_SHELL_EGL_ES_2_0_H
+#define RAMSES_PLATFORM_WAYLAND_SHELL_EGL_ES_2_0_H
+
+#include "PlatformFactory_Wayland_Shell_EGL/PlatformFactory_Wayland_Shell_EGL.h"
+
+namespace ramses_internal
+{
+    class Platform_Wayland_Shell_EGL_ES_2_0 : public PlatformFactory_Wayland_Shell_EGL
+    {
+    public:
+        Platform_Wayland_Shell_EGL_ES_2_0(const RendererConfig& rendererConfig);
+
+        virtual IDevice*      createDevice(IContext& context) override final;
+
+    protected:
+        void getContextAttributes(Vector<EGLint>& attributes) const override final;
+        void getSurfaceAttributes(UInt32 msaaSampleCount, Vector<EGLint>& attributes) const override final;
+    };
+}
+
+#endif

--- a/renderer/Platform/Platform_Wayland_Shell_EGL_ES_2_0/src/Platform_Wayland_Shell_EGL_ES_2_0.cpp
+++ b/renderer/Platform/Platform_Wayland_Shell_EGL_ES_2_0/src/Platform_Wayland_Shell_EGL_ES_2_0.cpp
@@ -1,0 +1,77 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2017 BMW Car IT GmbH
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#include "Platform_Wayland_Shell_EGL_ES_2_0/Platform_Wayland_Shell_EGL_ES_2_0.h"
+#include <EGL/eglext.h>
+#include "Context_EGL/Context_EGL.h"
+#include "Device_GL/Device_GL.h"
+#include "Utils/LogMacros.h"
+
+namespace ramses_internal
+{
+    IPlatformFactory* PlatformFactory_Base::CreatePlatformFactory(const RendererConfig& rendererConfig)
+    {
+        return new Platform_Wayland_Shell_EGL_ES_2_0(rendererConfig);
+    }
+
+    Platform_Wayland_Shell_EGL_ES_2_0::Platform_Wayland_Shell_EGL_ES_2_0(const RendererConfig& rendererConfig)
+        : PlatformFactory_Wayland_Shell_EGL(rendererConfig)
+    {
+    }
+
+    IDevice* Platform_Wayland_Shell_EGL_ES_2_0::createDevice(IContext& context)
+    {
+        Context_EGL* platformContext = getPlatformContext<Context_EGL>(context);
+        assert(0 != platformContext);
+        Device_GL* device = new Device_GL(*platformContext, 2, 0, true);
+        return addPlatformDevice(device);
+    }
+
+    void Platform_Wayland_Shell_EGL_ES_2_0::getSurfaceAttributes(UInt32 msaaSampleCount, Vector<EGLint>& attributes) const
+    {
+        attributes.clear();
+        attributes.reserve(20u);
+
+        attributes.push_back(EGL_SURFACE_TYPE);
+        attributes.push_back(EGL_WINDOW_BIT);
+
+        attributes.push_back(EGL_RENDERABLE_TYPE);
+        attributes.push_back(EGL_OPENGL_ES2_BIT);
+
+        attributes.push_back(EGL_RED_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_ALPHA_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_DEPTH_SIZE);
+        attributes.push_back(24);
+
+        attributes.push_back(EGL_STENCIL_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_SAMPLE_BUFFERS);
+        attributes.push_back((msaaSampleCount > 1) ? 1 : 0);
+
+        attributes.push_back(EGL_SAMPLES);
+        attributes.push_back((msaaSampleCount > 1) ? msaaSampleCount : 0);
+
+        attributes.push_back(EGL_NONE);
+    }
+
+    void Platform_Wayland_Shell_EGL_ES_2_0::getContextAttributes(Vector<EGLint>& attributes) const
+    {
+        attributes.clear();
+        attributes.reserve(2u);
+
+        attributes.push_back(EGL_CONTEXT_CLIENT_VERSION);
+        attributes.push_back(2);
+
+        attributes.push_back(EGL_NONE);
+    }
+}

--- a/renderer/Platform/Platform_X11_EGL_ES_2_0/CMakeLists.txt
+++ b/renderer/Platform/Platform_X11_EGL_ES_2_0/CMakeLists.txt
@@ -1,0 +1,29 @@
+#  -------------------------------------------------------------------------
+#  Copyright (C) 2018 BMW Car IT GmbH
+#  -------------------------------------------------------------------------
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#  -------------------------------------------------------------------------
+
+ACME_MODULE(
+
+    #==========================================================================
+    # general module information
+    #==========================================================================
+    NAME                    platform-x11-egl-es-2-0
+    TYPE                    STATIC_LIBRARY
+    ENABLE_INSTALL          ${ramses-sdk_INSTALL_STATIC_LIBS}
+
+    #==========================================================================
+    # files of this module
+    #==========================================================================
+    FILES_PRIVATE_HEADER    include/Platform_X11_EGL_ES_2_0/*.h
+    FILES_SOURCE            src/*.cpp
+
+    #==========================================================================
+    # dependencies
+    #==========================================================================
+    DEPENDENCIES            Surface_X11_EGL
+                            Device_GL
+)

--- a/renderer/Platform/Platform_X11_EGL_ES_2_0/include/Platform_X11_EGL_ES_2_0/Platform_X11_EGL_ES_2_0.h
+++ b/renderer/Platform/Platform_X11_EGL_ES_2_0/include/Platform_X11_EGL_ES_2_0/Platform_X11_EGL_ES_2_0.h
@@ -1,0 +1,29 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2014 BMW Car IT GmbH
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#ifndef RAMSES_PLATFORM_X11_EGL_ES_2_0_H
+#define RAMSES_PLATFORM_X11_EGL_ES_2_0_H
+
+#include "Surface_X11_EGL/PlatformFactory_X11_EGL.h"
+
+namespace ramses_internal
+{
+    class Platform_X11_EGL_ES_2_0 : public PlatformFactory_X11_EGL
+    {
+    public:
+        Platform_X11_EGL_ES_2_0(const RendererConfig& rendererConfig);
+
+        virtual IDevice*      createDevice(IContext& context) override final;
+
+    protected:
+        void getContextAttributes(Vector<EGLint>& attributes) const override final;
+        void getSurfaceAttributes(UInt32 msaaSampleCount, Vector<EGLint>& attributes) const override final;
+    };
+}
+
+#endif

--- a/renderer/Platform/Platform_X11_EGL_ES_2_0/src/Platform_X11_EGL_ES_2_0.cpp
+++ b/renderer/Platform/Platform_X11_EGL_ES_2_0/src/Platform_X11_EGL_ES_2_0.cpp
@@ -1,0 +1,77 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2014 BMW Car IT GmbH
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#include "Platform_X11_EGL_ES_2_0/Platform_X11_EGL_ES_2_0.h"
+#include <EGL/eglext.h>
+#include "Context_EGL/Context_EGL.h"
+#include "Device_GL/Device_GL.h"
+#include "Utils/LogMacros.h"
+
+namespace ramses_internal
+{
+    IPlatformFactory* PlatformFactory_Base::CreatePlatformFactory(const RendererConfig& rendererConfig)
+    {
+        return new Platform_X11_EGL_ES_2_0(rendererConfig);
+    }
+
+    Platform_X11_EGL_ES_2_0::Platform_X11_EGL_ES_2_0(const RendererConfig& rendererConfig)
+        : PlatformFactory_X11_EGL(rendererConfig)
+    {
+    }
+
+    IDevice* Platform_X11_EGL_ES_2_0::createDevice(IContext& context)
+    {
+        Context_EGL* platformContext = getPlatformContext<Context_EGL>(context);
+        assert(0 != platformContext);
+        Device_GL* device = new Device_GL(*platformContext, 2, 0, true);
+        return addPlatformDevice(device);
+    }
+
+    void Platform_X11_EGL_ES_2_0::getSurfaceAttributes(UInt32 msaaSampleCount, Vector<EGLint>& attributes) const
+    {
+        attributes.clear();
+        attributes.reserve(20u);
+
+        attributes.push_back(EGL_SURFACE_TYPE);
+        attributes.push_back(EGL_WINDOW_BIT);
+
+        attributes.push_back(EGL_RENDERABLE_TYPE);
+        attributes.push_back(EGL_OPENGL_ES2_BIT);
+
+        attributes.push_back(EGL_RED_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_ALPHA_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_DEPTH_SIZE);
+        attributes.push_back(24);
+
+        attributes.push_back(EGL_STENCIL_SIZE);
+        attributes.push_back(8);
+
+        attributes.push_back(EGL_SAMPLE_BUFFERS);
+        attributes.push_back((msaaSampleCount > 1) ? 1 : 0);
+
+        attributes.push_back(EGL_SAMPLES);
+        attributes.push_back((msaaSampleCount > 1) ? msaaSampleCount : 0);
+
+        attributes.push_back(EGL_NONE);
+    }
+
+    void Platform_X11_EGL_ES_2_0::getContextAttributes(Vector<EGLint>& attributes) const
+    {
+        attributes.clear();
+        attributes.reserve(2u);
+
+        attributes.push_back(EGL_CONTEXT_CLIENT_VERSION);
+        attributes.push_back(2);
+
+        attributes.push_back(EGL_NONE);
+    }
+}


### PR DESCRIPTION
Somehow, there is embedded platform which does not support GLES3 attributes. This makes a chance for EGL with GLES 2.0 attributes.

Tested 
- ramses-example-local-client
- ramses-example-basic
- remote and ramses client