### PR TITLE
Dynamic resizing: add resize event

### DIFF
--- a/integration/PlatformTests/RenderBackendTests/src/PlatformTest.cpp
+++ b/integration/PlatformTests/RenderBackendTests/src/PlatformTest.cpp
@@ -46,7 +46,7 @@ namespace ramses_internal
         IRenderBackend* createRenderBackend(bool multisampling = false, bool useDifferentIviId = false)
         {
             EXPECT_CALL(eventHandlerMock, onFocusChange(_)).Times(AnyNumber());
-            EXPECT_CALL(eventHandlerMock, onResize(_)).Times(AnyNumber());
+            EXPECT_CALL(eventHandlerMock, onResize(_, _)).Times(AnyNumber());
             EXPECT_CALL(eventHandlerMock, onMove(_)).Times(AnyNumber());
 
             DisplayConfig displayConfig;

--- a/integration/PlatformTests/RenderBackendTests/src/PlatformTest.cpp
+++ b/integration/PlatformTests/RenderBackendTests/src/PlatformTest.cpp
@@ -45,9 +45,7 @@ namespace ramses_internal
     protected:
         IRenderBackend* createRenderBackend(bool multisampling = false, bool useDifferentIviId = false)
         {
-            EXPECT_CALL(eventHandlerMock, onFocusChange(_)).Times(AnyNumber());
             EXPECT_CALL(eventHandlerMock, onResize(_, _)).Times(AnyNumber());
-            EXPECT_CALL(eventHandlerMock, onMove(_)).Times(AnyNumber());
 
             DisplayConfig displayConfig;
 

--- a/renderer/DisplayManager/include/DisplayManager/RendererEventChainer.h
+++ b/renderer/DisplayManager/include/DisplayManager/RendererEventChainer.h
@@ -202,6 +202,12 @@ namespace ramses_display_manager
             m_handler2.windowClosed(displayId);
         }
 
+        virtual void windowResized(ramses::displayId_t displayId, uint32_t width, uint32_t height) override
+        {
+            m_handler1.windowResized(displayId, width, height);
+            m_handler2.windowResized(displayId, width, height);
+        }
+
     private:
         ramses::IRendererEventHandler& m_handler1;
         ramses::IRendererEventHandler& m_handler2;

--- a/renderer/Platform/Window_Wayland_IVI/include/Window_Wayland_IVI/Window_Wayland_IVI.h
+++ b/renderer/Platform/Window_Wayland_IVI/include/Window_Wayland_IVI/Window_Wayland_IVI.h
@@ -10,6 +10,7 @@
 #define RAMSES_WINDOW_WAYLAND_IVI_H
 
 #include "Window_Wayland/Window_Wayland.h"
+#include "ivi-application-client-protocol.h"
 
 struct ivi_application;
 struct ivi_surface;
@@ -26,9 +27,21 @@ namespace ramses_internal
 
         virtual void registryGlobalCreated(wl_registry* wl_registry, uint32_t name, const char* interface, uint32_t version) override;
         virtual bool createSurface() override;
+        void registerSurfaceListener();
+
+        static void configureCallback(void* userData, ivi_surface* surface, int32_t width, int32_t height);
 
         ivi_application* m_iviApplicationRegistry = nullptr;
         ivi_surface*     m_iviApplicationSurface  = nullptr;
+
+        const struct IVI_Surface_Listener : public ivi_surface_listener
+        {
+            IVI_Surface_Listener()
+            {
+                configure = configureCallback;
+            }
+
+        } m_IVISurfaceListener;
     };
 }
 

--- a/renderer/Platform/Window_Wayland_IVI/src/Window_Wayland_IVI.cpp
+++ b/renderer/Platform/Window_Wayland_IVI/src/Window_Wayland_IVI.cpp
@@ -60,6 +60,18 @@ namespace ramses_internal
             LOG_ERROR(CONTEXT_RENDERER, "Window_Wayland_IVI::createSurface Failed to create ivi-application surface!");
             return false;
         }
+        registerSurfaceListener();
         return true;
+    }
+
+    void Window_Wayland_IVI::configureCallback(void* userData, ivi_surface* surface, int32_t width, int32_t height)
+    {
+        Window_Wayland_IVI* window = static_cast<Window_Wayland_IVI*>(userData);
+        (window->m_eventHandler).onResize(width, height);
+    }
+
+    void Window_Wayland_IVI::registerSurfaceListener()
+    {
+        ivi_surface_add_listener(m_iviApplicationSurface, &m_IVISurfaceListener, this);
     }
 }

--- a/renderer/Platform/Window_Wayland_IVI/src/Window_Wayland_IVI.cpp
+++ b/renderer/Platform/Window_Wayland_IVI/src/Window_Wayland_IVI.cpp
@@ -64,7 +64,7 @@ namespace ramses_internal
         return true;
     }
 
-    void Window_Wayland_IVI::configureCallback(void* userData, ivi_surface* surface, int32_t width, int32_t height)
+    void Window_Wayland_IVI::configureCallback(void* userData, ivi_surface* /*surface*/, int32_t width, int32_t height)
     {
         Window_Wayland_IVI* window = static_cast<Window_Wayland_IVI*>(userData);
         (window->m_eventHandler).onResize(width, height);

--- a/renderer/Platform/Window_Wayland_Shell/include/Window_Wayland_Shell/Window_Wayland_Shell.h
+++ b/renderer/Platform/Window_Wayland_Shell/include/Window_Wayland_Shell/Window_Wayland_Shell.h
@@ -26,9 +26,24 @@ namespace ramses_internal
                                            const char*  interface,
                                            uint32_t     version) override;
         virtual bool createSurface() override;
+        void registerSurfaceListener();
+
+        static void configureCallback(void* userData, wl_shell_surface* surface, uint32_t edges, int32_t width, int32_t height);
+        static void pingCallback(void* userData, wl_shell_surface* surface, uint32_t serial);
+        static void popupDoneCallback(void* userData, wl_shell_surface* surface);
 
         wl_shell*      m_shellRegistry = nullptr;
         wl_shell_surface* m_shellSurface  = nullptr;
+
+        const struct Shell_Surface_Listener : public wl_shell_surface_listener
+        {
+            Shell_Surface_Listener()
+            {
+                ping = pingCallback;
+                configure = configureCallback;
+                popup_done = popupDoneCallback;
+            }
+        } m_shellSurfaceListener;
     };
 }
 

--- a/renderer/Platform/Window_Wayland_Shell/src/Window_Wayland_Shell.cpp
+++ b/renderer/Platform/Window_Wayland_Shell/src/Window_Wayland_Shell.cpp
@@ -53,6 +53,7 @@ namespace ramses_internal
             m_shellSurface = wl_shell_get_shell_surface(m_shellRegistry, m_wlContext.surface);
             wl_shell_surface_set_title(m_shellSurface, m_windowName.c_str());
             wl_shell_surface_set_toplevel(m_shellSurface);
+            registerSurfaceListener();
         }
         else
         {
@@ -69,5 +70,29 @@ namespace ramses_internal
         {
             wl_shell_surface_set_title(m_shellSurface, m_windowName.c_str());
         }
+    }
+
+    void Window_Wayland_Shell::configureCallback(void* userData, wl_shell_surface* surface, uint32_t edges, int32_t width, int32_t height)
+    {
+        Window_Wayland_Shell* window = static_cast<Window_Wayland_Shell*>(userData);
+        (window->m_eventHandler).onResize(width, height);
+    }
+
+    void Window_Wayland_Shell::pingCallback(void* userData, wl_shell_surface* surface, uint32_t serial)
+    {
+        UNUSED(userData);
+        wl_shell_surface_pong(surface, serial);
+    }
+
+    void Window_Wayland_Shell::popupDoneCallback(void* userData, wl_shell_surface* surface)
+    {
+        UNUSED(userData);
+        UNUSED(surface);
+        LOG_DEBUG(CONTEXT_RENDERER, "Window_Wayland::popupDoneCallback called");
+    }
+
+    void Window_Wayland_Shell::registerSurfaceListener()
+    {
+        wl_shell_surface_add_listener(m_shellSurface, &m_shellSurfaceListener, this);
     }
 }

--- a/renderer/Platform/Window_Wayland_Shell/src/Window_Wayland_Shell.cpp
+++ b/renderer/Platform/Window_Wayland_Shell/src/Window_Wayland_Shell.cpp
@@ -74,8 +74,10 @@ namespace ramses_internal
 
     void Window_Wayland_Shell::configureCallback(void* userData, wl_shell_surface* surface, uint32_t edges, int32_t width, int32_t height)
     {
+        UNUSED(surface);
+        UNUSED(edges);
         Window_Wayland_Shell* window = static_cast<Window_Wayland_Shell*>(userData);
-        (window->m_eventHandler).onResize(width, height);
+        window->m_eventHandler.onResize(width, height);
     }
 
     void Window_Wayland_Shell::pingCallback(void* userData, wl_shell_surface* surface, uint32_t serial)

--- a/renderer/Platform/Window_Wayland_Test/include/Window_Wayland_Test/AWindowWaylandWithEventHandling.h
+++ b/renderer/Platform/Window_Wayland_Test/include/Window_Wayland_Test/AWindowWaylandWithEventHandling.h
@@ -78,7 +78,7 @@ namespace ramses_internal
 
             // process window creation related events
             EXPECT_CALL(this->m_eventHandlerMock, onFocusChange(_)).Times(AnyNumber());
-            EXPECT_CALL(this->m_eventHandlerMock, onResize(_)).Times(AnyNumber());
+            EXPECT_CALL(this->m_eventHandlerMock, onResize(_, _)).Times(AnyNumber());
             EXPECT_CALL(this->m_eventHandlerMock, onMove(_)).Times(AnyNumber());
             processAllEvents();
         }

--- a/renderer/Platform/Window_Wayland_Test/include/Window_Wayland_Test/AWindowWaylandWithEventHandling.h
+++ b/renderer/Platform/Window_Wayland_Test/include/Window_Wayland_Test/AWindowWaylandWithEventHandling.h
@@ -77,9 +77,8 @@ namespace ramses_internal
             makeWindowVisible();
 
             // process window creation related events
-            EXPECT_CALL(this->m_eventHandlerMock, onFocusChange(_)).Times(AnyNumber());
             EXPECT_CALL(this->m_eventHandlerMock, onResize(_, _)).Times(AnyNumber());
-            EXPECT_CALL(this->m_eventHandlerMock, onMove(_)).Times(AnyNumber());
+            EXPECT_CALL(this->m_eventHandlerMock, onClose()).Times(AnyNumber());
             processAllEvents();
         }
 

--- a/renderer/Platform/Window_Windows/src/Window_Windows.cpp
+++ b/renderer/Platform/Window_Windows/src/Window_Windows.cpp
@@ -503,6 +503,7 @@ namespace ramses_internal
             {
                 window->m_height = HIWORD(lParam);
                 window->m_width = LOWORD(lParam);
+                (window->eventHandler).onResize(m_width, m_height);
             }
         }
         break;

--- a/renderer/Platform/Window_Windows/src/Window_Windows.cpp
+++ b/renderer/Platform/Window_Windows/src/Window_Windows.cpp
@@ -503,7 +503,7 @@ namespace ramses_internal
             {
                 window->m_height = HIWORD(lParam);
                 window->m_width = LOWORD(lParam);
-                (window->eventHandler).onResize(m_width, m_height);
+                window->m_eventHandler.onResize(window->m_width, window->m_height);
             }
         }
         break;

--- a/renderer/Platform/Window_Windows/test/Window_Window_Test.cpp
+++ b/renderer/Platform/Window_Windows/test/Window_Window_Test.cpp
@@ -16,10 +16,10 @@ using namespace testing;
 
 namespace ramses_internal
 {
-    class WindowWindows : public testing::Test
+    class AWindowWindows : public testing::Test
     {
     public:
-        WindowWindows()
+        AWindowWindows()
             : window(config, eventHandlerMock, 0)
         {
         }
@@ -77,7 +77,7 @@ namespace ramses_internal
         EXPECT_EQ(Window_Windows::convertVirtualKeyCodeIntoRamsesKeyCode(0x73, 0), EKeyCode_F4);
     }
 
-    TEST_F(WindowWindows, singleKeyPressEventTriggersKeyPressedEventWithCorrectKeyCode)
+    TEST_F(AWindowWindows, singleKeyPressEventTriggersKeyPressedEventWithCorrectKeyCode)
     {
         testKeyCode(0x41,        EKeyCode_A);
         testKeyCode(0x30,        EKeyCode_0);
@@ -90,7 +90,7 @@ namespace ramses_internal
         testKeyCode(VK_SHIFT,    EKeyCode_ShiftLeft,     EKeyModifier_Shift);
     }
 
-    TEST_F(WindowWindows, leftMouseButtonDownEventTriggersLeftButtonDownEvent)
+    TEST_F(AWindowWindows, leftMouseButtonDownEventTriggersLeftButtonDownEvent)
     {
         sendMouseEvent(5, 10, WM_LBUTTONDOWN);
 
@@ -98,7 +98,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, leftMouseButtonUpEventTriggersLeftButtonUpEvent)
+    TEST_F(AWindowWindows, leftMouseButtonUpEventTriggersLeftButtonUpEvent)
     {
         sendMouseEvent(5, 10, WM_LBUTTONUP);
 
@@ -106,7 +106,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, rightMouseButtonDownEventTriggersRightButtonDownEvent)
+    TEST_F(AWindowWindows, rightMouseButtonDownEventTriggersRightButtonDownEvent)
     {
         sendMouseEvent(6, 11, WM_RBUTTONDOWN);
 
@@ -114,7 +114,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, rightMouseButtonUpEventTriggersRightButtonUpEvent)
+    TEST_F(AWindowWindows, rightMouseButtonUpEventTriggersRightButtonUpEvent)
     {
         sendMouseEvent(6, 11, WM_RBUTTONUP);
 
@@ -122,7 +122,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, middleMouseButtonDownEventTriggersMiddleButtonDownEvent)
+    TEST_F(AWindowWindows, middleMouseButtonDownEventTriggersMiddleButtonDownEvent)
     {
         sendMouseEvent(6, 11, WM_MBUTTONDOWN);
 
@@ -130,7 +130,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, middleMouseButtonUpEventTriggersMiddleButtonUpEvent)
+    TEST_F(AWindowWindows, middleMouseButtonUpEventTriggersMiddleButtonUpEvent)
     {
         sendMouseEvent(6, 11, WM_MBUTTONUP);
 
@@ -138,7 +138,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, positiveMouseWheelEventTriggersMouseWheelUpEvent)
+    TEST_F(AWindowWindows, positiveMouseWheelEventTriggersMouseWheelUpEvent)
     {
         const int packedWheelDelta = WHEEL_DELTA << 16;
         sendMouseEvent(7, 12, WM_MOUSEWHEEL, packedWheelDelta);
@@ -147,7 +147,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, negativeMouseWheelEventTriggersMouseWheelDownEvent)
+    TEST_F(AWindowWindows, negativeMouseWheelEventTriggersMouseWheelDownEvent)
     {
         const auto packedWheelDelta = static_cast<unsigned int>(-(WHEEL_DELTA << 16));
         sendMouseEvent(7, 12, WM_MOUSEWHEEL, packedWheelDelta);
@@ -156,7 +156,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, largeMouseWheelEventTriggersMultipleMouseWheelEvents)
+    TEST_F(AWindowWindows, largeMouseWheelEventTriggersMultipleMouseWheelEvents)
     {
         const int packedWheelDelta = (3*WHEEL_DELTA) << 16;
         sendMouseEvent(7, 12, WM_MOUSEWHEEL, packedWheelDelta);
@@ -165,7 +165,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, mouseMoveEventTriggersMouseMoveEvent)
+    TEST_F(AWindowWindows, mouseMoveEventTriggersMouseMoveEvent)
     {
         sendMouseEvent(5, 10, WM_MOUSEMOVE);
 
@@ -175,7 +175,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, mouseLeaveEventTriggersWindowLeaveEvent)
+    TEST_F(AWindowWindows, mouseLeaveEventTriggersWindowLeaveEvent)
     {
         sendMouseEvent(5, 10, WM_MOUSEMOVE); // to simulate a window leave event we have to enter the window first
         sendWindowLeaveEvent();
@@ -186,7 +186,7 @@ namespace ramses_internal
         processAllEvents();
     }
 
-    TEST_F(WindowWindows, mouseMoveEventTriggersWindowEnterEvent)
+    TEST_F(AWindowWindows, mouseMoveEventTriggersWindowEnterEvent)
     {
         sendWindowLeaveEvent(); // to simulate a window enter event we have to leave the window first
         sendMouseEvent(5, 10, WM_MOUSEMOVE);

--- a/renderer/Platform/Window_Windows/test/Window_Window_Test.cpp
+++ b/renderer/Platform/Window_Windows/test/Window_Window_Test.cpp
@@ -77,6 +77,26 @@ namespace ramses_internal
         EXPECT_EQ(Window_Windows::convertVirtualKeyCodeIntoRamsesKeyCode(0x73, 0), EKeyCode_F4);
     }
 
+    TEST(Window_Windows, propagatesResizeEvents)
+    {
+        DisplayConfig config;
+        config.setResizable(true);
+        NiceMock<WindowEventHandlerMock> eventHandlerMock;
+        Window_Windows window(config, eventHandlerMock, 0);
+
+        ASSERT_TRUE(window.init());
+        for (UInt32 i = 0; i < 10; i++) // enforce handling of all enqueued window events which will trigger our event handler
+            window.handleEvents();
+
+        const uint32_t width = 15;
+        const uint32_t height = 20;
+        const int packedWindowSize = (static_cast<int>(height) << 16) | width;
+        ASSERT_TRUE(PostMessage(window.getNativeWindowHandle(), WM_SIZE, 0, packedWindowSize));
+
+        EXPECT_CALL(eventHandlerMock, onResize(15, 20)).Times(1);
+        window.handleEvents();
+    }
+
     TEST_F(AWindowWindows, singleKeyPressEventTriggersKeyPressedEventWithCorrectKeyCode)
     {
         testKeyCode(0x41,        EKeyCode_A);

--- a/renderer/Platform/Window_X11/src/Window_X11.cpp
+++ b/renderer/Platform/Window_X11/src/Window_X11.cpp
@@ -410,6 +410,7 @@ namespace ramses_internal
                 {
                     m_width = static_cast<UInt32>(event.xconfigure.width);
                     m_height = static_cast<UInt32>(event.xconfigure.height);
+                    m_eventHandler.onResize(m_width, m_height);
                 }
             }
                 break;

--- a/renderer/RendererLib/RendererAPI/include/RendererAPI/IWindowEventHandler.h
+++ b/renderer/RendererLib/RendererAPI/include/RendererAPI/IWindowEventHandler.h
@@ -25,6 +25,7 @@ namespace ramses_internal
         virtual void onKeyEvent(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode) = 0;
         virtual void onMouseEvent(EMouseEventType event, Int32 posX, Int32 posY) = 0;
         virtual void onClose() = 0;
+        virtual void onResize(Int32 width, Int32 height) = 0;
     };
 }
 

--- a/renderer/RendererLib/RendererAPI/include/RendererAPI/IWindowEventHandler.h
+++ b/renderer/RendererLib/RendererAPI/include/RendererAPI/IWindowEventHandler.h
@@ -25,7 +25,7 @@ namespace ramses_internal
         virtual void onKeyEvent(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode) = 0;
         virtual void onMouseEvent(EMouseEventType event, Int32 posX, Int32 posY) = 0;
         virtual void onClose() = 0;
-        virtual void onResize(Int32 width, Int32 height) = 0;
+        virtual void onResize(UInt32 width, UInt32 height) = 0;
     };
 }
 

--- a/renderer/RendererLib/RendererLib/include/RendererEventCollector.h
+++ b/renderer/RendererLib/RendererLib/include/RendererEventCollector.h
@@ -81,6 +81,7 @@ namespace ramses_internal
         ERendererEventType_WindowClosed,
         ERendererEventType_WindowKeyEvent,
         ERendererEventType_WindowMouseEvent,
+        ERendererEventType_WindowResizeEvent,
         ERendererEventType_StreamSurfaceAvailable,
         ERendererEventType_StreamSurfaceUnavailable,
 
@@ -140,6 +141,7 @@ namespace ramses_internal
         "ERendererEventType_WindowClosed",
         "ERendererEventType_WindowKeyEvent",
         "ERendererEventType_WindowMouseEvent",
+        "ERendererEventType_WindowResizeEvent",
         "ERendererEventType_StreamSurfaceAvailable",
         "ERendererEventType_StreamSurfaceUnavailable"
     };
@@ -157,6 +159,12 @@ namespace ramses_internal
         EKeyEventType type = EKeyEventType_Invalid;
         UInt32        modifier;
         EKeyCode      keyCode;
+    };
+
+    struct ResizeEvent
+    {
+        UInt32 width;
+        UInt32 height;
     };
 
     struct RendererEvent
@@ -179,6 +187,7 @@ namespace ramses_internal
         SceneVersionTag             sceneVersionTag;
         EResourceStatus             resourceStatus = EResourceStatus_Unknown;
         MouseEvent                  mouseEvent;
+        ResizeEvent                 resizeEvent;
         KeyEvent                    keyEvent;
         StreamTextureSourceId       streamSourceId;
     };
@@ -314,6 +323,14 @@ namespace ramses_internal
             RendererEvent event(eventType);
             event.displayHandle = display;
             event.keyEvent = keyEvent;
+            pushEventToQueue(event);
+        }
+
+        void addEvent(ERendererEventType eventType, DisplayHandle display, ResizeEvent resizeEvent)
+        {
+            RendererEvent event(eventType);
+            event.displayHandle = display;
+            event.resizeEvent = resizeEvent;
             pushEventToQueue(event);
         }
 

--- a/renderer/RendererLib/RendererLib/include/RendererLib/DisplayEventHandler.h
+++ b/renderer/RendererLib/RendererLib/include/RendererLib/DisplayEventHandler.h
@@ -27,6 +27,7 @@ namespace ramses_internal
         virtual void onKeyEvent(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode) override;
         virtual void onMouseEvent(EMouseEventType event, Int32 posX, Int32 posY) override;
         virtual void onClose() override;
+        virtual void onResize(Int32 width, Int32 height) override;
 
     private:
         const DisplayHandle     m_displayHandle;

--- a/renderer/RendererLib/RendererLib/include/RendererLib/DisplayEventHandler.h
+++ b/renderer/RendererLib/RendererLib/include/RendererLib/DisplayEventHandler.h
@@ -27,7 +27,7 @@ namespace ramses_internal
         virtual void onKeyEvent(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode) override;
         virtual void onMouseEvent(EMouseEventType event, Int32 posX, Int32 posY) override;
         virtual void onClose() override;
-        virtual void onResize(Int32 width, Int32 height) override;
+        virtual void onResize(UInt32 width, UInt32 height) override;
 
     private:
         const DisplayHandle     m_displayHandle;

--- a/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
+++ b/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
@@ -60,4 +60,10 @@ namespace ramses_internal
         // collect renderer event
         m_eventCollector.addEvent(ERendererEventType_WindowClosed, m_displayHandle);
     }
+
+    void DisplayEventHandler::onResize(Int32 width, Int32 height)
+    {
+        UNUSED(width);
+        UNUSED(height);
+    }
 }

--- a/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
+++ b/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
@@ -63,7 +63,9 @@ namespace ramses_internal
 
     void DisplayEventHandler::onResize(UInt32 width, UInt32 height)
     {
-        UNUSED(width);
-        UNUSED(height);
+       ResizeEvent resizeEvent;
+       resizeEvent.width = width;
+       resizeEvent.height = height;
+       m_eventCollector.addEvent(ERendererEventType_WindowResizeEvent, m_displayHandle, resizeEvent);
     }
 }

--- a/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
+++ b/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
@@ -61,7 +61,7 @@ namespace ramses_internal
         m_eventCollector.addEvent(ERendererEventType_WindowClosed, m_displayHandle);
     }
 
-    void DisplayEventHandler::onResize(Int32 width, Int32 height)
+    void DisplayEventHandler::onResize(UInt32 width, UInt32 height)
     {
         UNUSED(width);
         UNUSED(height);

--- a/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
+++ b/renderer/RendererLib/RendererLib/src/DisplayEventHandler.cpp
@@ -63,9 +63,6 @@ namespace ramses_internal
 
     void DisplayEventHandler::onResize(UInt32 width, UInt32 height)
     {
-       ResizeEvent resizeEvent;
-       resizeEvent.width = width;
-       resizeEvent.height = height;
-       m_eventCollector.addEvent(ERendererEventType_WindowResizeEvent, m_displayHandle, resizeEvent);
+       m_eventCollector.addEvent(ERendererEventType_WindowResizeEvent, m_displayHandle, ResizeEvent{width, height});
     }
 }

--- a/renderer/RendererLib/RendererLib/test/DisplayEventHandlerTest.cpp
+++ b/renderer/RendererLib/RendererLib/test/DisplayEventHandlerTest.cpp
@@ -122,3 +122,12 @@ TEST_F(ADisplayEventHandler, createsRendererEventOnWindowClosedEvent)
     EXPECT_EQ(ERendererEventType_WindowClosed, event.eventType);
     EXPECT_EQ(m_displayHandle, event.displayHandle);
 }
+
+TEST_F(ADisplayEventHandler, createsRendererEventOnWindowResizeEvent)
+{
+    m_displayEventHandler.onResize(1280u, 480u);
+
+    const RendererEvent event = getRendererEvent(0u);
+    EXPECT_EQ(ERendererEventType_WindowResizeEvent, event.eventType);
+    EXPECT_EQ(m_displayHandle, event.displayHandle);
+}

--- a/renderer/RendererLib/RendererLib/test/DisplayEventHandlerTest.cpp
+++ b/renderer/RendererLib/RendererLib/test/DisplayEventHandlerTest.cpp
@@ -130,4 +130,6 @@ TEST_F(ADisplayEventHandler, createsRendererEventOnWindowResizeEvent)
     const RendererEvent event = getRendererEvent(0u);
     EXPECT_EQ(ERendererEventType_WindowResizeEvent, event.eventType);
     EXPECT_EQ(m_displayHandle, event.displayHandle);
+    EXPECT_EQ(1280u, event.resizeEvent.width);
+    EXPECT_EQ(480u, event.resizeEvent.height);
 }

--- a/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
+++ b/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
@@ -23,7 +23,7 @@ namespace ramses_internal
         WindowEventHandlerMock();
         ~WindowEventHandlerMock() override;
 
-        MOCK_METHOD1(onResize, void(Int32 width, Int32 height));
+        MOCK_METHOD2(onResize, void(Int32 width, Int32 height));
         MOCK_METHOD1(onMove, void(const IWindow& surface));
         MOCK_METHOD1(onFocusChange, void(Bool bFocused));
         MOCK_METHOD3(onKeyEvent, void(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode));

--- a/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
+++ b/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
@@ -23,7 +23,7 @@ namespace ramses_internal
         WindowEventHandlerMock();
         ~WindowEventHandlerMock() override;
 
-        MOCK_METHOD1(onResize, void(const IWindow& surface));
+        MOCK_METHOD1(onResize, void(Int32 width, Int32 height));
         MOCK_METHOD1(onMove, void(const IWindow& surface));
         MOCK_METHOD1(onFocusChange, void(Bool bFocused));
         MOCK_METHOD3(onKeyEvent, void(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode));

--- a/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
+++ b/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
@@ -23,7 +23,7 @@ namespace ramses_internal
         WindowEventHandlerMock();
         ~WindowEventHandlerMock() override;
 
-        MOCK_METHOD2(onResize, void(Int32 width, Int32 height));
+        MOCK_METHOD2(onResize, void(UInt32 width, UInt32 height));
         MOCK_METHOD1(onMove, void(const IWindow& surface));
         MOCK_METHOD1(onFocusChange, void(Bool bFocused));
         MOCK_METHOD3(onKeyEvent, void(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode));

--- a/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
+++ b/renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h
@@ -24,8 +24,6 @@ namespace ramses_internal
         ~WindowEventHandlerMock() override;
 
         MOCK_METHOD2(onResize, void(UInt32 width, UInt32 height));
-        MOCK_METHOD1(onMove, void(const IWindow& surface));
-        MOCK_METHOD1(onFocusChange, void(Bool bFocused));
         MOCK_METHOD3(onKeyEvent, void(EKeyEventType event, UInt32 modifiers, EKeyCode keyCode));
         MOCK_METHOD3(onMouseEvent, void(EMouseEventType event, Int32 posX, Int32 posY));
         MOCK_METHOD0(onClose, void());

--- a/renderer/RendererLib/ramses-renderer-api/include/ramses-renderer-api/IRendererEventHandler.h
+++ b/renderer/RendererLib/ramses-renderer-api/include/ramses-renderer-api/IRendererEventHandler.h
@@ -282,6 +282,14 @@ namespace ramses
         virtual void mouseEvent(displayId_t displayId, EMouseEvent eventType, int32_t mousePosX, int32_t mousePosY) = 0;
 
         /**
+        * @brief This method will be called when a display's window has been resized
+        * @param displayId The ramses display whose corresponding window was resized
+        * @param width The new width of the window
+        * @param height The new height of the window
+        */
+        virtual void windowResized(displayId_t displayId, uint32_t width, uint32_t height) = 0;
+
+        /**
         * @brief This method will be called when a display's window has been closed
         * @param displayId The display on which the event occurred
         */
@@ -564,7 +572,6 @@ namespace ramses
             (void)keyCode;
         }
 
-
         /**
         * @copydoc ramses::IRendererEventHandler::mouseEvent
         */
@@ -574,6 +581,16 @@ namespace ramses
             (void)eventType;
             (void)mousePosX;
             (void)mousePosY;
+        }
+
+        /**
+        * @copydoc ramses::IRendererEventHandler::windowResized
+        */
+        virtual void windowResized(displayId_t displayId, uint32_t width, uint32_t height) override
+        {
+            (void)displayId;
+            (void)width;
+            (void)height;
         }
 
         /**

--- a/renderer/RendererLib/ramses-renderer-impl/src/RamsesRendererImpl.cpp
+++ b/renderer/RendererLib/ramses-renderer-impl/src/RamsesRendererImpl.cpp
@@ -592,6 +592,9 @@ namespace ramses
                     RamsesRendererUtils::GetMouseEvent(event.mouseEvent.type),
                     event.mouseEvent.pos.x, event.mouseEvent.pos.y);
                 break;
+            case ramses_internal::ERendererEventType_WindowResizeEvent:
+                rendererEventHandler.windowResized(event.displayHandle.asMemoryHandle(), event.resizeEvent.width, event.resizeEvent.height);
+                break;
             case ramses_internal::ERendererEventType_StreamSurfaceAvailable:
                 rendererEventHandler.streamAvailabilityChanged(ramses::streamSource_t(event.streamSourceId.getValue()), true);
                 break;

--- a/renderer/RendererLib/ramses-renderer-impl/test/RamsesRendererDispatchTest.cpp
+++ b/renderer/RendererLib/ramses-renderer-impl/test/RamsesRendererDispatchTest.cpp
@@ -728,6 +728,15 @@ namespace ramses_internal
         m_handler.expectWindowClosed(m_displayId);
     }
 
+    TEST_F(ARamsesRendererDispatch, generatesEventForWindowResized)
+    {
+        const ramses::displayId_t m_displayId = createDisplayAndExpectResult();
+        const ramses_internal::DisplayHandle displayHandle(m_displayId);
+        m_renderer.impl.getRenderer().getRenderer().getDisplayEventHandler(displayHandle).onResize(100, 200);
+        updateAndDispatch(m_handler);
+        m_handler.expectWindowResized(m_displayId, 100, 200);
+    }
+
     TEST_F(ARamsesRendererDispatch, generatesEventForKeyPressed)
     {
         const ramses::displayId_t m_displayId = createDisplayAndExpectResult();

--- a/renderer/RendererLib/ramses-renderer-impl/test/RendererEventTestHandler.h
+++ b/renderer/RendererLib/ramses-renderer-impl/test/RendererEventTestHandler.h
@@ -51,6 +51,7 @@ enum ERendererEventTestType
     ERendererEventTestType_SceneExpired,
     ERendererEventTestType_SceneRecoveredAfterExpiration,
     ERendererEventTestType_WindowClosed,
+    ERendererEventTestType_WindowResized,
     ERendererEventTestType_KeyEvent,
     ERendererEventTestType_MouseEvent
 };
@@ -80,7 +81,9 @@ struct RendererTestEvent
             && keyCode == other.keyCode
             && mouseEvent == other.mouseEvent
             && mousePosX == other.mousePosX
-            && mousePosY == other.mousePosY;
+            && mousePosY == other.mousePosY
+            && windowWidth == other.windowWidth
+            && windowHeight == other.windowHeight;
     }
 
     ERendererEventTestType eventType;
@@ -105,6 +108,8 @@ struct RendererTestEvent
     ramses::EMouseEvent mouseEvent;
     int32_t mousePosX;
     int32_t mousePosY;
+    uint32_t windowWidth;
+    uint32_t windowHeight;
 };
 
 class RendererEventTestHandler : public ramses::IRendererEventHandler
@@ -364,6 +369,16 @@ public:
         RendererTestEvent event;
         event.eventType = ERendererEventTestType_WindowClosed;
         event.displayId = displayId;
+        m_events.push_back(event);
+    }
+
+    virtual void windowResized(ramses::displayId_t displayId, uint32_t width, uint32_t height)
+    {
+        RendererTestEvent event;
+        event.eventType = ERendererEventTestType_WindowResized;
+        event.displayId = displayId;
+        event.windowWidth = width;
+        event.windowHeight = height;
         m_events.push_back(event);
     }
 
@@ -639,6 +654,16 @@ public:
         RendererTestEvent event;
         event.eventType = ERendererEventTestType_WindowClosed;
         event.displayId = displayId;
+        expectEvent(event);
+    }
+
+    void expectWindowResized(ramses::displayId_t displayId, uint32_t width, uint32_t height)
+    {
+        RendererTestEvent event;
+        event.eventType = ERendererEventTestType_WindowResized;
+        event.displayId = displayId;
+        event.windowWidth = width;
+        event.windowHeight = height;
         expectEvent(event);
     }
 


### PR DESCRIPTION
Window resize events are now captured from the underlying windowing
system for all major platforms and passed to the framework via
onResize(width, height).

Unfortunately, current code does not compile due to some mismatch in "renderer/RendererLib/RendererTestUtils/include/WindowEventHandlerMock.h"

Partially addresses #7 