### PR TITLE
Embedded compositor: add missing include

### DIFF
--- a/renderer/Platform/EmbeddedCompositor_Wayland/include/EmbeddedCompositor_Wayland/IWaylandClient.h
+++ b/renderer/Platform/EmbeddedCompositor_Wayland/include/EmbeddedCompositor_Wayland/IWaylandClient.h
@@ -8,6 +8,9 @@
 #ifndef RAMSES_IWAYLANDCLIENT_H
 #define RAMSES_IWAYLANDCLIENT_H
 
+// For pid_t, uid_t, gid_t
+#include <unistd.h>
+
 namespace ramses_internal
 {
     class IWaylandResource;


### PR DESCRIPTION
IWaylandClient.h used pid_t/uid_t/gid_t that come from system headers,
but hadn't been including those headers. This was not noticed
because most .cpp files using IWaylandClient.h had by coincidence
already included the necessary headers.

Fix this by defensively include the necessary headers.