### PR TITLE
Scene viewer: add screenshot feature

### DIFF
--- a/utils/ramses-scene-viewer/src/SceneViewer.h
+++ b/utils/ramses-scene-viewer/src/SceneViewer.h
@@ -9,10 +9,14 @@
 #ifndef RAMSES_SCENE_VIEWER_SCENEVIEWER_H
 #define RAMSES_SCENE_VIEWER_SCENEVIEWER_H
 
+#include <memory>
 #include "Utils/CommandLineParser.h"
 #include "Utils/Argument.h"
 #include "Collections/String.h"
 #include "ramses-framework-api/RamsesFrameworkTypes.h"
+#include "ramses-renderer-api/IRendererEventHandler.h"
+#include "ramses-renderer-api/RamsesRenderer.h"
+#include "ScreenshotSaver.h"
 
 namespace ramses
 {
@@ -41,6 +45,11 @@ namespace ramses_internal
         ArgumentString m_scenePathAndFileArgument;
         ArgumentString m_optionalResFileArgument;
         ArgumentString m_validationUnrequiredObjectsDirectoryArgument;
+        ArgumentString m_screenshotFile;
+        ArgumentUInt32 m_screenshotWidth;
+        ArgumentUInt32 m_screenshotHeight;
+
+        std::unique_ptr<ramses::ScreenshotSaver> m_screenshotSaver;
     };
 }
 

--- a/utils/ramses-scene-viewer/src/ScreenshotSaver.cpp
+++ b/utils/ramses-scene-viewer/src/ScreenshotSaver.cpp
@@ -1,0 +1,49 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida (dwlsalmeida@gmail.com)
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#include <cstring>
+#include "Collections/String.h"
+#include "ScreenshotSaver.h"
+// TODO should not use ramses internals
+#include "Utils/Image.h"
+
+namespace ramses
+{
+
+        ScreenshotSaver::ScreenshotSaver(RamsesRenderer& renderer, displayId_t displayId, uint32_t width, uint32_t height, std::string filename)
+            : m_renderer{renderer}
+            , m_displayId{displayId}
+            , m_width{width}
+            , m_height{height}
+            , m_filename(filename)
+        {
+        };
+
+        void ScreenshotSaver::sceneShown(sceneId_t sceneId, ERendererEventResult result)
+        {
+            UNUSED(sceneId);
+            if (result == ERendererEventResult_OK)
+            {
+                m_renderer.readPixels(m_displayId, 0, 0, m_width, m_height);
+                m_renderer.flush();
+            }
+        }
+
+        void ScreenshotSaver::framebufferPixelsRead(const uint8_t* pixelData, const uint32_t pixelDataSize, displayId_t displayId, ERendererEventResult result)
+        {
+            UNUSED(displayId);
+            if (result == ramses::ERendererEventResult_OK)
+            {
+                assert(pixelDataSize == m_width * m_height * 4);
+
+                ramses_internal::Image image(m_width, m_height, pixelData, pixelData + pixelDataSize, true);
+                image.saveToFilePNG(m_filename.c_str());
+            }
+        }
+
+}

--- a/utils/ramses-scene-viewer/src/ScreenshotSaver.h
+++ b/utils/ramses-scene-viewer/src/ScreenshotSaver.h
@@ -1,0 +1,39 @@
+//  -------------------------------------------------------------------------
+//  Copyright (C) 2019 Daniel Werner Lima Souza de Almeida (dwlsalmeida@gmail.com)
+//  -------------------------------------------------------------------------
+//  This Source Code Form is subject to the terms of the Mozilla Public
+//  License, v. 2.0. If a copy of the MPL was not distributed with this
+//  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//  -------------------------------------------------------------------------
+
+#ifndef RAMSES_SCENE_VIEWER_SCREENSHOTSAVER_H
+#define RAMSES_SCENE_VIEWER_SCREENSHOTSAVER_H
+
+#include <vector>
+#include "Collections/String.h"
+#include "ramses-framework-api/RamsesFrameworkTypes.h"
+#include "ramses-renderer-api/IRendererEventHandler.h"
+#include "ramses-renderer-api/RamsesRenderer.h"
+
+namespace ramses
+{
+    class ScreenshotSaver final : public ramses::RendererEventHandlerEmpty
+    {
+
+    public:
+        ScreenshotSaver(ramses::RamsesRenderer& renderer, ramses::displayId_t displayId, uint32_t width, uint32_t height, std::string filename);
+
+        virtual void framebufferPixelsRead(const uint8_t* pixelData, const uint32_t pixelDataSize, ramses::displayId_t displayId, ramses::ERendererEventResult result) override;
+        virtual void sceneShown(ramses::sceneId_t sceneId, ramses::ERendererEventResult result) override;
+
+    private:
+        ramses::RamsesRenderer& m_renderer;
+        ramses::displayId_t m_displayId;
+
+        uint32_t m_width;
+        uint32_t m_height;
+        std::string m_filename;
+    };
+}
+
+#endif


### PR DESCRIPTION
Add an optional screenshot feature to the RAMSES Scene Viewer, which can be activated by supplying a CLI flag (-x / --screenshot). This hasn't been thoroughly debugged yet, but some feedback on the general approach is appreciated.


