### PR TITLE
Fix missing EGL Wayland function prototypes

### DIFF
--- a/renderer/Platform/TextureUploadingAdapter_Wayland/include/TextureUploadingAdapter_Wayland/WaylandEGLExtensionProcs.h
+++ b/renderer/Platform/TextureUploadingAdapter_Wayland/include/TextureUploadingAdapter_Wayland/WaylandEGLExtensionProcs.h
@@ -23,6 +23,12 @@ WARNINGS_POP
 
 #include "Collections/String.h"
 
+#ifndef EGL_WAYLAND_BUFFER_WL
+    #define EGL_WAYLAND_BUFFER_WL 0x31D5
+#endif
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLUNBINDWAYLANDDISPLAYWL) (EGLDisplay dpy, struct wl_display *display);
+
 namespace ramses_internal
 {
     class WaylandEGLExtensionProcs


### PR DESCRIPTION
On some platforms, the EGL Wayland function prototypes are not included
in eglext.h.