### PR TITLE
Explicit stated the default copy assignment operator

### DIFF
--- a/framework/Animation/Animation/include/Animation/AnimationTime.h
+++ b/framework/Animation/Animation/include/Animation/AnimationTime.h
@@ -22,6 +22,8 @@ namespace ramses_internal
         AnimationTime(TimeStamp timeStamp = InvalidTimeStamp);
         AnimationTime(const AnimationTime& other);
 
+        AnimationTime& operator=(const AnimationTime& other) = default;
+
         Bool isValid() const;
         Duration getDurationSince(const AnimationTime& other) const;
         TimeStamp getTimeStamp() const;

--- a/framework/Core/Common/include/Common/StronglyTypedValue.h
+++ b/framework/Core/Common/include/Common/StronglyTypedValue.h
@@ -49,6 +49,8 @@ namespace ramses_internal
             return m_value;
         }
 
+        StronglyTypedValue& operator=(const StronglyTypedValue& other) = default;
+
         constexpr bool operator==(const StronglyTypedValue& other) const
         {
             return m_value == other.m_value;


### PR DESCRIPTION
GCC sine 9.0 version returns a "deprecated-copy" warning

Two components need to have their default copy assignment operators explicitly defined as "default"

in glslang there is a PR already
https://github.com/KhronosGroup/glslang/pull/1940
